### PR TITLE
Migrate to using elementId

### DIFF
--- a/database/api/src/main/java/com/albertoventurini/graphdbplugin/database/api/GraphDatabaseApi.java
+++ b/database/api/src/main/java/com/albertoventurini/graphdbplugin/database/api/GraphDatabaseApi.java
@@ -6,6 +6,7 @@
  */
 package com.albertoventurini.graphdbplugin.database.api;
 
+import com.albertoventurini.graphdbplugin.database.api.data.GraphDatabaseVersion;
 import com.albertoventurini.graphdbplugin.database.api.data.GraphMetadata;
 import com.albertoventurini.graphdbplugin.database.api.query.GraphQueryResult;
 
@@ -18,4 +19,6 @@ public interface GraphDatabaseApi {
     GraphQueryResult execute(String query, Map<String, Object> statementParameters);
 
     GraphMetadata metadata();
+
+    GraphDatabaseVersion getVersion();
 }

--- a/database/api/src/main/java/com/albertoventurini/graphdbplugin/database/api/data/GraphDatabaseVersion.java
+++ b/database/api/src/main/java/com/albertoventurini/graphdbplugin/database/api/data/GraphDatabaseVersion.java
@@ -1,0 +1,15 @@
+/**
+ * Copied and adapted from plugin
+ * <a href="https://github.com/neueda/jetbrains-plugin-graph-database-support">Graph Database Support</a>
+ * by Neueda Technologies, Ltd.
+ * Modified by Alberto Venturini, 2022
+ */
+package com.albertoventurini.graphdbplugin.database.api.data;
+
+public interface GraphDatabaseVersion {
+    String toString();
+
+    String idFunction();
+
+    Object idToParameter(String id);
+}

--- a/database/neo4j/src/main/java/com/albertoventurini/graphdbplugin/database/neo4j/bolt/data/Neo4jBoltNode.java
+++ b/database/neo4j/src/main/java/com/albertoventurini/graphdbplugin/database/neo4j/bolt/data/Neo4jBoltNode.java
@@ -21,7 +21,7 @@ public class Neo4jBoltNode implements GraphNode {
     private final List<String> types;
 
     public Neo4jBoltNode(Node value) {
-        this.id = String.valueOf(value.id());
+        this.id = String.valueOf(value.elementId());
         this.types = Iterables.asList(value.labels());
         this.propertyContainer = new Neo4jBoltPropertyContainer(value.asMap());
     }

--- a/database/neo4j/src/main/java/com/albertoventurini/graphdbplugin/database/neo4j/bolt/data/Neo4jBoltRelationship.java
+++ b/database/neo4j/src/main/java/com/albertoventurini/graphdbplugin/database/neo4j/bolt/data/Neo4jBoltRelationship.java
@@ -26,12 +26,12 @@ public class Neo4jBoltRelationship implements GraphRelationship {
     private GraphNode endNode;
 
     public Neo4jBoltRelationship(Relationship rel) {
-        this.id = String.valueOf(rel.id());
+        this.id = String.valueOf(rel.elementId());
         this.types = Collections.singletonList(rel.type());
         this.propertyContainer = new Neo4jBoltPropertyContainer(rel.asMap());
 
-        this.startNodeId = String.valueOf(rel.startNodeId());
-        this.endNodeId = String.valueOf(rel.endNodeId());
+        this.startNodeId = String.valueOf(rel.startNodeElementId());
+        this.endNodeId = String.valueOf(rel.endNodeElementId());
     }
 
     public Neo4jBoltRelationship(String id, List<String> types, GraphPropertyContainer propertyContainer, String startNodeId, String endNodeId) {

--- a/database/neo4j/src/main/java/com/albertoventurini/graphdbplugin/database/neo4j/bolt/data/Neo4jGraphDatabaseVersion.java
+++ b/database/neo4j/src/main/java/com/albertoventurini/graphdbplugin/database/neo4j/bolt/data/Neo4jGraphDatabaseVersion.java
@@ -1,0 +1,33 @@
+/**
+ * Copied and adapted from plugin
+ * <a href="https://github.com/neueda/jetbrains-plugin-graph-database-support">Graph Database Support</a>
+ * by Neueda Technologies, Ltd.
+ * Modified by Alberto Venturini, 2022
+ */
+package com.albertoventurini.graphdbplugin.database.neo4j.bolt.data;
+
+import com.albertoventurini.graphdbplugin.database.api.data.GraphDatabaseVersion;
+
+public record Neo4jGraphDatabaseVersion(int major, int minor, int patch) implements GraphDatabaseVersion {
+
+    @Override
+    public String toString() {
+        return "Neo4j/" + major + "." + minor + "." + patch;
+    }
+
+    @Override
+    public String idFunction() {
+        if (major >= 5) {
+            return "elementId";
+        }
+        return "id";
+    }
+
+    @Override
+    public Object idToParameter(String id) {
+        if (major >= 5) {
+            return id;
+        }
+        return Long.parseLong(id);
+    }
+}

--- a/graph-database-plugin/src/main/resources/META-INF/plugin.xml
+++ b/graph-database-plugin/src/main/resources/META-INF/plugin.xml
@@ -130,6 +130,8 @@
                 serviceImplementation="com.albertoventurini.graphdbplugin.jetbrains.ui.datasource.DataSourcesView"/>
         <projectService
                 serviceImplementation="com.albertoventurini.graphdbplugin.jetbrains.ui.console.params.ParametersService"/>
+        <projectService
+                serviceImplementation="com.albertoventurini.graphdbplugin.jetbrains.database.VersionService"/>
 
         <scratch.rootType implementation="com.albertoventurini.graphdbplugin.jetbrains.ui.datasource.interactions.GraphDbEditorsConsoleRootType"/>
         <scratch.rootType implementation="com.albertoventurini.graphdbplugin.jetbrains.ui.console.params.ParameterRootType"/>

--- a/platform/src/main/java/icons/GraphIcons.java
+++ b/platform/src/main/java/icons/GraphIcons.java
@@ -27,6 +27,7 @@ public final class GraphIcons {
     }
 
     public static final class Nodes {
+        public static final Icon VERSION = AllIcons.Actions.InlayGear;
         public static final Icon INDEX = AllIcons.Nodes.ResourceBundle;
         public static final Icon CONSTRAINT = AllIcons.Nodes.C_protected;
         public static final Icon LABEL = AllIcons.Nodes.Class;

--- a/testing/integration-neo4j/build.gradle
+++ b/testing/integration-neo4j/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     testImplementation project(':graph-database-plugin')
     testImplementation project(':ui:jetbrains')
     testImplementation project(':language:cypher')
+    testImplementation project(':database:api')
     testImplementation project(':database:neo4j')
     testImplementation project(':testing:common')
     testImplementation project(':platform')

--- a/testing/integration-neo4j/src/test/java/com/albertoventurini/graphdbplugin/test/integration/neo4j/tests/database/common/AbstractDataSourceMetadataTest.java
+++ b/testing/integration-neo4j/src/test/java/com/albertoventurini/graphdbplugin/test/integration/neo4j/tests/database/common/AbstractDataSourceMetadataTest.java
@@ -7,11 +7,9 @@
 package com.albertoventurini.graphdbplugin.test.integration.neo4j.tests.database.common;
 
 import com.albertoventurini.graphdbplugin.jetbrains.component.datasource.metadata.DataSourceMetadata;
-import com.albertoventurini.graphdbplugin.jetbrains.component.datasource.metadata.neo4j.Neo4jProcedureMetadata;
 import com.albertoventurini.graphdbplugin.jetbrains.component.datasource.state.DataSourceApi;
 import com.albertoventurini.graphdbplugin.test.integration.neo4j.util.base.BaseIntegrationTest;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -32,13 +30,13 @@ public abstract class AbstractDataSourceMetadataTest extends BaseIntegrationTest
     public abstract DataSourceApi getDataSource();
 
     public void testMetadataExists() throws ExecutionException, InterruptedException {
-        Optional<DataSourceMetadata> metadata = component().dataSourcesMetadata().getMetadata(getDataSource()).get();
+        Optional<DataSourceMetadata> metadata = component().dataSourcesMetadata().updateMetadata(getDataSource()).get();
         assertThat(metadata).isPresent();
     }
 
     protected DataSourceMetadata getMetadata() {
         try {
-            CompletableFuture<Optional<DataSourceMetadata>> futureMeta = component().dataSourcesMetadata().getMetadata(getDataSource());
+            CompletableFuture<Optional<DataSourceMetadata>> futureMeta = component().dataSourcesMetadata().updateMetadata(getDataSource());
             return futureMeta.get(30, TimeUnit.SECONDS)
                     .orElseThrow(() -> new IllegalStateException("Metadata should not be null"));
         } catch (InterruptedException | ExecutionException | TimeoutException e) {

--- a/testing/integration-neo4j/src/test/java/com/albertoventurini/graphdbplugin/test/integration/neo4j/tests/database/neo4j/DataSourceMetadataTest.java
+++ b/testing/integration-neo4j/src/test/java/com/albertoventurini/graphdbplugin/test/integration/neo4j/tests/database/neo4j/DataSourceMetadataTest.java
@@ -6,6 +6,7 @@
  */
 package com.albertoventurini.graphdbplugin.test.integration.neo4j.tests.database.neo4j;
 
+import com.albertoventurini.graphdbplugin.database.neo4j.bolt.data.Neo4jGraphDatabaseVersion;
 import com.albertoventurini.graphdbplugin.jetbrains.component.datasource.metadata.neo4j.Neo4jMetadata;
 import com.albertoventurini.graphdbplugin.jetbrains.component.datasource.metadata.neo4j.Neo4jFunctionMetadata;
 import com.albertoventurini.graphdbplugin.jetbrains.component.datasource.metadata.neo4j.Neo4jProcedureMetadata;
@@ -38,5 +39,12 @@ public class DataSourceMetadataTest extends AbstractDataSourceMetadataTest {
                 p.name().equals("db.labels")
                         && p.signature().equals("db.labels() :: (label :: STRING?)")
                         && p.description().equals("List all available labels in the database.")));
+    }
+
+    public void testGetVersion() {
+        var metadata = (Neo4jMetadata) getMetadata();
+        var version = (Neo4jGraphDatabaseVersion) metadata.version();
+        assertEquals(version.major(), 5);
+        assertEquals(version.minor(), 2);
     }
 }

--- a/testing/integration-neo4j/src/test/java/com/albertoventurini/graphdbplugin/test/integration/neo4j/tests/database/neo4j/DataSourceMetadataTest.java
+++ b/testing/integration-neo4j/src/test/java/com/albertoventurini/graphdbplugin/test/integration/neo4j/tests/database/neo4j/DataSourceMetadataTest.java
@@ -44,7 +44,7 @@ public class DataSourceMetadataTest extends AbstractDataSourceMetadataTest {
     public void testGetVersion() {
         var metadata = (Neo4jMetadata) getMetadata();
         var version = (Neo4jGraphDatabaseVersion) metadata.version();
-        assertEquals(version.major(), 5);
-        assertEquals(version.minor(), 2);
+        assertEquals(5, version.major());
+        assertEquals(2, version.minor());
     }
 }

--- a/ui/jetbrains/src/main/java/com/albertoventurini/graphdbplugin/jetbrains/component/datasource/DataSourcesComponent.java
+++ b/ui/jetbrains/src/main/java/com/albertoventurini/graphdbplugin/jetbrains/component/datasource/DataSourcesComponent.java
@@ -57,9 +57,7 @@ public class DataSourcesComponent implements PersistentStateComponent<DataSource
     }
 
     public void refreshAllMetadata() {
-        getDataSourceContainer().getDataSources().forEach(d -> {
-            componentMetadata.getMetadata(d);
-        });
+        getDataSourceContainer().getDataSources().forEach(componentMetadata::updateMetadata);
     }
 //
 //    @NotNull

--- a/ui/jetbrains/src/main/java/com/albertoventurini/graphdbplugin/jetbrains/component/datasource/metadata/neo4j/Neo4jMetadata.java
+++ b/ui/jetbrains/src/main/java/com/albertoventurini/graphdbplugin/jetbrains/component/datasource/metadata/neo4j/Neo4jMetadata.java
@@ -1,10 +1,12 @@
 package com.albertoventurini.graphdbplugin.jetbrains.component.datasource.metadata.neo4j;
 
+import com.albertoventurini.graphdbplugin.database.api.data.GraphDatabaseVersion;
 import com.albertoventurini.graphdbplugin.jetbrains.component.datasource.metadata.DataSourceMetadata;
 
 import java.util.*;
 
 public record Neo4jMetadata(
+        GraphDatabaseVersion version,
         List<Neo4jFunctionMetadata> functions,
         List<Neo4jProcedureMetadata> procedures,
         List<Neo4jConstraintMetadata> constraints,

--- a/ui/jetbrains/src/main/java/com/albertoventurini/graphdbplugin/jetbrains/component/datasource/metadata/neo4j/Neo4jMetadataBuilder.java
+++ b/ui/jetbrains/src/main/java/com/albertoventurini/graphdbplugin/jetbrains/component/datasource/metadata/neo4j/Neo4jMetadataBuilder.java
@@ -1,6 +1,8 @@
 package com.albertoventurini.graphdbplugin.jetbrains.component.datasource.metadata.neo4j;
 
 import com.albertoventurini.graphdbplugin.database.api.GraphDatabaseApi;
+import com.albertoventurini.graphdbplugin.database.api.data.GraphDatabaseVersion;
+import com.albertoventurini.graphdbplugin.database.neo4j.bolt.data.Neo4jGraphDatabaseVersion;
 import com.albertoventurini.graphdbplugin.database.neo4j.bolt.query.Neo4jBoltQueryResultRow;
 import com.albertoventurini.graphdbplugin.jetbrains.component.datasource.metadata.DataSourceMetadata;
 import com.albertoventurini.graphdbplugin.jetbrains.component.datasource.metadata.MetadataBuilder;
@@ -50,6 +52,7 @@ public class Neo4jMetadataBuilder implements MetadataBuilder {
         final var databaseManager = ApplicationManager.getApplication().getService(DatabaseManagerService.class);
         final GraphDatabaseApi db = databaseManager.getDatabaseFor(dataSource);
 
+        GraphDatabaseVersion version = new Neo4jGraphDatabaseVersion(0, 0, 0);
         final List<Neo4jIndexMetadata> indexes = new ArrayList<>();
         final List<Neo4jProcedureMetadata> procedures = new ArrayList<>();
         final List<Neo4jConstraintMetadata> constraints = new ArrayList<>();
@@ -60,8 +63,9 @@ public class Neo4jMetadataBuilder implements MetadataBuilder {
             procedures.addAll(getProcedures(db));
             constraints.addAll(getConstraints(db));
             functions.addAll(getFunctions(db));
+            version = db.getVersion();
         } catch (Exception e) {
-            LOG.warn("Unable to load indexes, constraints, procedures, or functions from the current database. Please upgrade to Neo4j 4.2+ to fix this.");
+            LOG.warn("Unable to load indexes, constraints, procedures, functions, or version from the current database. Please upgrade to Neo4j 4.2+ to fix this.");
         }
 
         final var propertyKeys = getPropertyKeys(db);
@@ -69,6 +73,7 @@ public class Neo4jMetadataBuilder implements MetadataBuilder {
         final var relationshipTypes = getRelationshipTypes(db);
 
         return new Neo4jMetadata(
+                version,
                 functions,
                 procedures,
                 constraints,

--- a/ui/jetbrains/src/main/java/com/albertoventurini/graphdbplugin/jetbrains/database/VersionService.java
+++ b/ui/jetbrains/src/main/java/com/albertoventurini/graphdbplugin/jetbrains/database/VersionService.java
@@ -1,0 +1,69 @@
+/**
+ * Copied and adapted from plugin
+ * <a href="https://github.com/neueda/jetbrains-plugin-graph-database-support">Graph Database Support</a>
+ * by Neueda Technologies, Ltd.
+ * Modified by Alberto Venturini, 2022
+ */
+package com.albertoventurini.graphdbplugin.jetbrains.database;
+
+import com.albertoventurini.graphdbplugin.database.api.data.GraphDatabaseVersion;
+import com.albertoventurini.graphdbplugin.jetbrains.component.datasource.state.DataSourceApi;
+import com.albertoventurini.graphdbplugin.jetbrains.services.ExecutorService;
+import com.albertoventurini.graphdbplugin.jetbrains.ui.console.event.VersionFetchingProcessEvent;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.util.messages.MessageBus;
+
+import java.util.HashMap;
+import java.util.concurrent.CompletableFuture;
+
+public final class VersionService {
+    private final HashMap<String, CompletableFuture<GraphDatabaseVersion>> versionRegistry;
+    private final MessageBus messageBus;
+    private final DatabaseManagerService databaseManager;
+    private final ExecutorService executorService;
+
+    VersionService(Project project) {
+        versionRegistry = new HashMap<>();
+        messageBus = project.getMessageBus();
+        databaseManager = ApplicationManager.getApplication().getService(DatabaseManagerService.class);
+        executorService = ApplicationManager.getApplication().getService(ExecutorService.class);
+    }
+
+    public synchronized CompletableFuture<GraphDatabaseVersion> getVersion(DataSourceApi api) {
+        final var key = api.getName();
+        final var version = versionRegistry.get(key);
+        if (version != null && !version.isCompletedExceptionally()) {
+            return version;
+        }
+        final var future = fetchVersion(api);
+        versionRegistry.put(key, future);
+        return future;
+    }
+
+    public synchronized void updatedVersion(DataSourceApi api, GraphDatabaseVersion version) {
+        final var key = api.getName();
+        final var future = new CompletableFuture<GraphDatabaseVersion>();
+        future.complete(version);
+        versionRegistry.put(key, future);
+    }
+
+    private CompletableFuture<GraphDatabaseVersion> fetchVersion(DataSourceApi api) {
+        VersionFetchingProcessEvent event = messageBus.syncPublisher(VersionFetchingProcessEvent.VERSION_FETCHING_PROCESS_TOPIC);
+        event.processStarted(api);
+        final var future = new CompletableFuture<GraphDatabaseVersion>();
+        final var db = databaseManager.getDatabaseFor(api);
+        executorService.runInBackground(
+                db::getVersion,
+                version -> {
+                    event.versionReceived(version);
+                    future.complete(version);
+                },
+                ex -> {
+                    event.handleError(ex);
+                    future.completeExceptionally(ex);
+                }
+        );
+        return future;
+    }
+}

--- a/ui/jetbrains/src/main/java/com/albertoventurini/graphdbplugin/jetbrains/ui/console/event/VersionFetchingProcessEvent.java
+++ b/ui/jetbrains/src/main/java/com/albertoventurini/graphdbplugin/jetbrains/ui/console/event/VersionFetchingProcessEvent.java
@@ -1,0 +1,24 @@
+/**
+ * Copied and adapted from plugin
+ * <a href="https://github.com/neueda/jetbrains-plugin-graph-database-support">Graph Database Support</a>
+ * by Neueda Technologies, Ltd.
+ * Modified by Alberto Venturini, 2022
+ */
+package com.albertoventurini.graphdbplugin.jetbrains.ui.console.event;
+
+import com.albertoventurini.graphdbplugin.database.api.data.GraphDatabaseVersion;
+import com.albertoventurini.graphdbplugin.jetbrains.component.datasource.state.DataSourceApi;
+import com.intellij.util.messages.Topic;
+
+public interface VersionFetchingProcessEvent {
+
+    Topic<VersionFetchingProcessEvent> VERSION_FETCHING_PROCESS_TOPIC =
+            Topic.create("GraphDatabaseConsole.VersionFetchingProcessTopic", VersionFetchingProcessEvent.class);
+
+    void processStarted(DataSourceApi dataSource);
+
+    void versionReceived(GraphDatabaseVersion version);
+
+
+    void handleError(Exception exception);
+}

--- a/ui/jetbrains/src/main/java/com/albertoventurini/graphdbplugin/jetbrains/ui/console/log/LogPanel.java
+++ b/ui/jetbrains/src/main/java/com/albertoventurini/graphdbplugin/jetbrains/ui/console/log/LogPanel.java
@@ -6,10 +6,12 @@
  */
 package com.albertoventurini.graphdbplugin.jetbrains.ui.console.log;
 
+import com.albertoventurini.graphdbplugin.database.api.data.GraphDatabaseVersion;
 import com.albertoventurini.graphdbplugin.jetbrains.actions.execute.ExecuteQueryPayload;
 import com.albertoventurini.graphdbplugin.jetbrains.component.datasource.state.DataSourceApi;
 import com.albertoventurini.graphdbplugin.jetbrains.ui.console.event.QueryExecutionProcessEvent;
 import com.albertoventurini.graphdbplugin.jetbrains.ui.console.event.QueryParametersRetrievalErrorEvent;
+import com.albertoventurini.graphdbplugin.jetbrains.ui.console.event.VersionFetchingProcessEvent;
 import com.albertoventurini.graphdbplugin.jetbrains.ui.datasource.interactions.DataSourceDialog;
 import com.albertoventurini.graphdbplugin.jetbrains.ui.datasource.metadata.MetadataRetrieveEvent;
 import com.intellij.execution.filters.TextConsoleBuilderFactory;
@@ -17,7 +19,6 @@ import com.intellij.execution.ui.ConsoleView;
 import com.intellij.execution.ui.ConsoleViewContentType;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.Disposable;
-import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.popup.IconButton;
 import com.intellij.openapi.ui.popup.JBPopupFactory;
@@ -26,7 +27,6 @@ import com.intellij.ui.components.JBScrollPane;
 import com.intellij.util.messages.MessageBus;
 import com.intellij.util.ui.JBUI;
 import com.albertoventurini.graphdbplugin.database.api.query.GraphQueryResult;
-import com.albertoventurini.graphdbplugin.jetbrains.component.datasource.metadata.DataSourceMetadata;
 import com.albertoventurini.graphdbplugin.jetbrains.ui.console.GraphConsoleView;
 import org.jetbrains.annotations.Nullable;
 
@@ -104,6 +104,26 @@ public class LogPanel implements Disposable {
             @Override
             public void executionCompleted(ExecuteQueryPayload payload) {
                 newLine();
+            }
+        });
+
+        messageBus.connect().subscribe(VersionFetchingProcessEvent.VERSION_FETCHING_PROCESS_TOPIC, new VersionFetchingProcessEvent() {
+            @Override
+            public void processStarted(DataSourceApi dataSource) {
+                info(String.format("Fetching database version for %s:", dataSource.getName()));
+                newLine();
+            }
+
+            @Override
+            public void versionReceived(GraphDatabaseVersion version) {
+                info(String.format("Version discovered: %s", version));
+                newLine();
+            }
+
+            @Override
+            public void handleError(Exception exception) {
+                error("Error occurred: ");
+                printException(exception);
             }
         });
 

--- a/ui/jetbrains/src/main/java/com/albertoventurini/graphdbplugin/jetbrains/ui/datasource/metadata/DataSourceMetadataUpdateService.java
+++ b/ui/jetbrains/src/main/java/com/albertoventurini/graphdbplugin/jetbrains/ui/datasource/metadata/DataSourceMetadataUpdateService.java
@@ -59,15 +59,15 @@ public final class DataSourceMetadataUpdateService {
         final DataSourceType sourceType = nodeDataSource.getDataSourceType();
 
         return treeUpdaters.get(sourceType)
-                .map(updater -> getMetadataAndApplyHandler(updater, node, nodeDataSource))
+                .map(updater -> updateMetadataAndApplyHandler(updater, node, nodeDataSource))
                 .orElse(completedFuture(false));
     }
 
-    private CompletableFuture<Boolean> getMetadataAndApplyHandler(
+    private CompletableFuture<Boolean> updateMetadataAndApplyHandler(
             final DataSourceTreeUpdater updater,
             final PatchedDefaultMutableTreeNode node,
             final DataSourceApi nodeDataSource) {
-        return dataSourcesComponent.getMetadata(nodeDataSource)
+        return dataSourcesComponent.updateMetadata(nodeDataSource)
                 .thenApply(data -> data.map(d -> {
                         updater.updateTree(node, d);
                         return true;

--- a/ui/jetbrains/src/main/java/com/albertoventurini/graphdbplugin/jetbrains/ui/datasource/metadata/Neo4jBoltTreeUpdater.java
+++ b/ui/jetbrains/src/main/java/com/albertoventurini/graphdbplugin/jetbrains/ui/datasource/metadata/Neo4jBoltTreeUpdater.java
@@ -1,5 +1,6 @@
 package com.albertoventurini.graphdbplugin.jetbrains.ui.datasource.metadata;
 
+import com.albertoventurini.graphdbplugin.database.api.data.GraphDatabaseVersion;
 import com.albertoventurini.graphdbplugin.jetbrains.component.datasource.metadata.neo4j.*;
 import com.albertoventurini.graphdbplugin.jetbrains.component.datasource.state.DataSourceApi;
 import com.albertoventurini.graphdbplugin.jetbrains.ui.datasource.tree.LabelTreeNodeModel;
@@ -20,6 +21,7 @@ import static com.albertoventurini.graphdbplugin.jetbrains.ui.datasource.tree.Ne
  */
 final class Neo4jBoltTreeUpdater implements DataSourceTreeUpdater<Neo4jMetadata> {
 
+    private static final String VERSION_TITLE = "version: %s";
     private static final String RELATIONSHIP_TYPES_TITLE = "relationship types (%s)";
     private static final String PROPERTY_KEYS_TITLE = "property keys";
     private static final String LABELS_TITLE = "labels (%s)";
@@ -38,6 +40,7 @@ final class Neo4jBoltTreeUpdater implements DataSourceTreeUpdater<Neo4jMetadata>
         TreeNodeModelApi model = (TreeNodeModelApi) dataSourceRootTreeNode.getUserObject();
         DataSourceApi dataSourceApi = model.getDataSourceApi();
 
+        dataSourceRootTreeNode.add(createVersionNode(neo4jMetadata.version(), dataSourceApi));
         dataSourceRootTreeNode.add(createConstraintsNode(neo4jMetadata.constraints(), dataSourceApi));
         dataSourceRootTreeNode.add(createIndexesNode(neo4jMetadata.indexes(), dataSourceApi));
         dataSourceRootTreeNode.add(createLabelsNode(neo4jMetadata, dataSourceApi));
@@ -53,6 +56,16 @@ final class Neo4jBoltTreeUpdater implements DataSourceTreeUpdater<Neo4jMetadata>
         }
     }
 
+    @NotNull
+    private PatchedDefaultMutableTreeNode createVersionNode(
+            final GraphDatabaseVersion version,
+            final DataSourceApi dataSourceApi) {
+        return of(new MetadataTreeNodeModel(
+                VERSION,
+                dataSourceApi,
+                VERSION_TITLE.formatted(version.toString()),
+                GraphIcons.Nodes.VERSION));
+    }
     @NotNull
     private PatchedDefaultMutableTreeNode createFunctionNode(
             final List<Neo4jFunctionMetadata> functionMetadata,

--- a/ui/jetbrains/src/main/java/com/albertoventurini/graphdbplugin/jetbrains/ui/datasource/tree/Neo4jTreeNodeType.java
+++ b/ui/jetbrains/src/main/java/com/albertoventurini/graphdbplugin/jetbrains/ui/datasource/tree/Neo4jTreeNodeType.java
@@ -9,6 +9,7 @@ package com.albertoventurini.graphdbplugin.jetbrains.ui.datasource.tree;
 public enum Neo4jTreeNodeType implements NodeType {
     ROOT,
     DATASOURCE,
+    VERSION,
     INDEXES,
     INDEX,
     CONSTRAINTS,

--- a/ui/jetbrains/src/test/java/com/albertoventurini/graphdbplugin/jetbrains/ui/datasource/metadata/ContextMenuTest.java
+++ b/ui/jetbrains/src/test/java/com/albertoventurini/graphdbplugin/jetbrains/ui/datasource/metadata/ContextMenuTest.java
@@ -6,6 +6,7 @@
  */
 package com.albertoventurini.graphdbplugin.jetbrains.ui.datasource.metadata;
 
+import com.albertoventurini.graphdbplugin.database.neo4j.bolt.data.Neo4jGraphDatabaseVersion;
 import com.albertoventurini.graphdbplugin.jetbrains.component.datasource.DataSourceType;
 import com.albertoventurini.graphdbplugin.jetbrains.component.datasource.metadata.neo4j.*;
 import com.albertoventurini.graphdbplugin.jetbrains.ui.datasource.metadata.dto.DataSourceContextMenu;
@@ -28,11 +29,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 
-import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 
 /**
  * Test that the correct context menu is associated with
@@ -71,6 +68,7 @@ public class ContextMenuTest extends LightJavaCodeInsightFixtureTestCase {
                 "List all labels in the database.");
 
         final Neo4jMetadata metadata = new Neo4jMetadata(
+                new Neo4jGraphDatabaseVersion(0, 0, 0),
                 Collections.emptyList(),
                 Collections.singletonList(procedure),
                 Collections.singletonList(constraintMetadata),

--- a/ui/jetbrains/src/test/java/com/albertoventurini/graphdbplugin/jetbrains/ui/datasource/metadata/DataSourceMetadataUpdateServiceTest.java
+++ b/ui/jetbrains/src/test/java/com/albertoventurini/graphdbplugin/jetbrains/ui/datasource/metadata/DataSourceMetadataUpdateServiceTest.java
@@ -33,7 +33,7 @@ public class DataSourceMetadataUpdateServiceTest extends LightJavaCodeInsightFix
         final var treeUpdaters = mock(DataSourceTreeUpdaters.class);
 
         final var dataSourceMetadata = mock(DataSourceMetadata.class);
-        when(metadataComponent.getMetadata(any()))
+        when(metadataComponent.updateMetadata(any()))
                 .thenReturn(CompletableFuture.completedFuture(Optional.of(dataSourceMetadata)));
 
         final var treeUpdater = mock(DataSourceTreeUpdater.class);

--- a/ui/jetbrains/src/test/java/com/albertoventurini/graphdbplugin/jetbrains/ui/datasource/metadata/Neo4JBoltTreeUpdaterTest.java
+++ b/ui/jetbrains/src/test/java/com/albertoventurini/graphdbplugin/jetbrains/ui/datasource/metadata/Neo4JBoltTreeUpdaterTest.java
@@ -6,6 +6,7 @@
  */
 package com.albertoventurini.graphdbplugin.jetbrains.ui.datasource.metadata;
 
+import com.albertoventurini.graphdbplugin.database.neo4j.bolt.data.Neo4jGraphDatabaseVersion;
 import com.albertoventurini.graphdbplugin.jetbrains.component.datasource.DataSourceType;
 import com.albertoventurini.graphdbplugin.jetbrains.component.datasource.metadata.neo4j.*;
 import com.albertoventurini.graphdbplugin.jetbrains.component.datasource.state.impl.DataSourceV1;
@@ -58,6 +59,7 @@ public class Neo4JBoltTreeUpdaterTest {
                 "List all labels in the database.");
 
         final Neo4jMetadata metadata = new Neo4jMetadata(
+                new Neo4jGraphDatabaseVersion(0, 0, 0),
                 Collections.emptyList(),
                 Collections.singletonList(procedure),
                 Collections.singletonList(constraintMetadata),


### PR DESCRIPTION
The cypher function `id` has been deprecated since Neo4j 5.0. This PR adds the capability of sniffing the DBMS version so that the DiffService can write an update query that matches the server version.

Likewise has `entity.id()` in the driver been deprecated. The driver will set `elementId` to `id.toString()` if the server does not provide it (4.4 and before). Therefore, it's safe to always use `entity.elementId()` regardless of the server version.